### PR TITLE
fix a simple typo in a lesson—perhaps in a relatively non-obvious loc…

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -115,4 +115,4 @@ from `R`:
 `download.file("https://ndownloader.figshare.com/files/11492171","data/SAFI_clean.csv", mode = "wb")`
 
 * The [json episode](https://datacarpentry.org/r-socialsci/06-json/index.html) uses 
-`SAFI.json`. The downlink link is <https://raw.githubusercontent.com/datacarpentry/r-socialsci/main/data/SAFI.json>.
+`SAFI.json`. The download link is <https://raw.githubusercontent.com/datacarpentry/r-socialsci/main/data/SAFI.json>.


### PR DESCRIPTION
Per the [pre-beta tasks](https://carpentries.github.io/workbench/beta-phase.html#pre-beta-tasks): "fix a simple typo in a lesson—perhaps in a relatively non-obvious location e.g. in the setup instructions"